### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -75,6 +79,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of fixNES, so the core can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of `libretro/Makefile` is arch-neutral and the emulator is plain portable C with no x86-specific code.

The job mirrors `libretro-build-linux-x64`:

```yaml
# Linux ARM 64-bit
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

plus the matching `/linux-aarch64.yml` template include. The file uses CRLF line endings; the patch keeps them.

Verified natively on aarch64 (postmarketOS on a Snapdragon 670 Chromebook, glibc, GCC 15): `make platform=unix` in `libretro/` builds clean with no source changes, producing `fixnes_libretro.so` (ELF 64-bit ARM aarch64). Running a commercial NES ROM in a minimal libretro host it emulates 300 frames at 256x240 / 60.10 fps with correct audio pacing (3722 frames per `retro_run` at 223721 Hz), about 557% of realtime.
